### PR TITLE
Add support for SSL connections

### DIFF
--- a/lib/Mojolicious/Plugin/AutoReload.pm
+++ b/lib/Mojolicious/Plugin/AutoReload.pm
@@ -112,7 +112,11 @@ sub register {
                 <script>
                     // If we lose our websocket connection, the web server must
                     // be restarting, and we should reload the page
-                    var autoReloadWs = new WebSocket( "ws://" + location.host + "$auto_reload_end_point" );
+                    var proto = "ws";
+                    if ( document.location.protocol === "https:" ) {
+                        proto = "wss";
+                    }
+                    var autoReloadWs = new WebSocket( proto + "://" + location.host + "$auto_reload_end_point" );
                     autoReloadWs.addEventListener( "close", function (event) {
                         // Wait one second then force a reload from the server
                         setTimeout( function () { location.reload(true); }, 1000 );


### PR DESCRIPTION
This allows the JavaScript to set the proper protocol based on the currently loaded version of the site.
This makes working with Chrome possible because it does not allow mix-content. Thus if you are testing a SSL version of your site, you cannot use AutoReload.
